### PR TITLE
Tweaked STATIC_QUIT and STATIC_PART and integrates with previously known ANTI_SPAM_QUIT_MESSAGE_TIME

### DIFF
--- a/include/dynconf.h
+++ b/include/dynconf.h
@@ -95,7 +95,6 @@ struct zConfiguration {
 	OperStat *oper_only_stats_ext;
 	int  maxchannelsperuser;
 	int  maxdccallow;
-	int  anti_spam_quit_message_time;
 	char *egd_path;
 	char *static_quit;
 	char *static_part;
@@ -192,7 +191,6 @@ extern MODVAR aConfiguration iConf;
 #define FAILOPER_WARN			iConf.fail_oper_warn
 #define SHOWCONNECTINFO			iConf.show_connect_info
 #define OPER_ONLY_STATS			iConf.oper_only_stats
-#define ANTI_SPAM_QUIT_MSG_TIME		iConf.anti_spam_quit_message_time
 #define USE_EGD				iConf.use_egd
 #define EGD_PATH			iConf.egd_path
 
@@ -318,7 +316,6 @@ struct SetCheck {
 	unsigned has_oper_only_stats:1;
 	unsigned has_maxchannelsperuser:1;
 	unsigned has_maxdccallow:1;
-	unsigned has_anti_spam_quit_message_time:1;
 	unsigned has_egd_path:1;
 	unsigned has_static_quit:1;
 	unsigned has_static_part:1;

--- a/include/dynconf.h
+++ b/include/dynconf.h
@@ -96,6 +96,8 @@ struct zConfiguration {
 	int  maxchannelsperuser;
 	int  maxdccallow;
 	char *egd_path;
+	int static_quit_part_set;
+	int static_quit_part_time;
 	char *static_quit;
 	char *static_part;
 #ifdef USE_SSL
@@ -213,6 +215,8 @@ extern MODVAR aConfiguration iConf;
 #define SSL_SERVER_CERT_PEM		(iConf.x_server_cert_pem ? iConf.x_server_cert_pem : "server.cert.pem")
 #define SSL_SERVER_KEY_PEM		(iConf.x_server_key_pem ? iConf.x_server_key_pem : "server.key.pem")
 
+#define STATIC_QUIT_PART_SET		iConf.static_quit_part_set
+#define STATIC_QUIT_PART_TIME		iConf.static_quit_part_time
 #define STATIC_QUIT			iConf.static_quit
 #define STATIC_PART			iConf.static_part
 #define UHOST_ALLOWED			iConf.userhost_allowed
@@ -317,6 +321,8 @@ struct SetCheck {
 	unsigned has_maxchannelsperuser:1;
 	unsigned has_maxdccallow:1;
 	unsigned has_egd_path:1;
+	unsigned has_static_quit_part_set:1;
+	unsigned has_static_quit_part_time:1;
 	unsigned has_static_quit:1;
 	unsigned has_static_part:1;
 #ifdef USE_SSL

--- a/src/modules/m_part.c
+++ b/src/modules/m_part.c
@@ -101,12 +101,16 @@ DLLFUNC CMD_FUNC(m_part)
 			commentx = NULL;
 		if (STATIC_PART)
 		{
-			if (!strcasecmp(STATIC_PART, "yes") || !strcmp(STATIC_PART, "1"))
-				commentx = NULL;
-			else if (!strcasecmp(STATIC_PART, "no") || !strcmp(STATIC_PART, "0"))
-				; /* keep original reason */
+			if (STATIC_QUIT_PART_TIME == -1)
+			{
+				if!(IsLoggedIn(sptr) && STATIC_QUIT_PART_SET)
+					commentx = STATIC_PART;
+			}
 			else
-				commentx = STATIC_PART;
+				/* we only care of users within the time range -dboyz */
+				if (sptr->firsttime+STATIC_QUIT_PART_TIME > TStime())
+					if!(IsLoggedIn(sptr) && STATIC_QUIT_PART_SET)
+						commentx = STATIC_PART;
 		}
 		if (commentx)
 		{

--- a/src/modules/m_quit.c
+++ b/src/modules/m_quit.c
@@ -101,13 +101,13 @@ DLLFUNC int  m_quit(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			if (STATIC_QUIT_PART_TIME == -1)
 			{
 				if!(IsLoggedIn(sptr) && STATIC_QUIT_PART_SET)
-					return exit_client(cptr, sptr, sptr, "Client Quit");
+					return exit_client(cptr, sptr, sptr, STATIC_QUIT);
 			}
 			else
 				/* we only care of users within the time range -dboyz */
 				if (sptr->firsttime+STATIC_QUIT_PART_TIME > TStime())
 					if!(IsLoggedIn(sptr) && STATIC_QUIT_PART_SET)
-						return exit_client(cptr, sptr, sptr, "Client Quit");
+						return exit_client(cptr, sptr, sptr, STATIC_QUIT);
 		}
 		if (IsVirus(sptr))
 			return exit_client(cptr, sptr, sptr, "Client exited");

--- a/src/modules/m_stats.c
+++ b/src/modules/m_stats.c
@@ -1224,8 +1224,6 @@ int stats_set(aClient *sptr, char *para)
 	if (uhallow)
 		sendto_one(sptr, ":%s %i %s :allow-userhost-change: %s", me.name, RPL_TEXT,
 			sptr->name, uhallow);
-	sendto_one(sptr, ":%s %i %s :anti-spam-quit-message-time: %s", me.name, RPL_TEXT, 
-		sptr->name, pretty_time_val(ANTI_SPAM_QUIT_MSG_TIME));
 	sendto_one(sptr, ":%s %i %s :channel-command-prefix: %s", me.name, RPL_TEXT, sptr->name, CHANCMDPFX ? CHANCMDPFX : "`");
 #ifdef USE_SSL
 	sendto_one(sptr, ":%s %i %s :ssl::egd: %s", me.name, RPL_TEXT,
@@ -1266,6 +1264,24 @@ int stats_set(aClient *sptr, char *para)
 	    sptr->name, AUTO_JOIN_CHANS ? AUTO_JOIN_CHANS : "0");
 	sendto_one(sptr, ":%s %i %s :oper-auto-join: %s", me.name,
 	    RPL_TEXT, sptr->name, OPER_AUTO_JOIN_CHANS ? OPER_AUTO_JOIN_CHANS : "0");
+	if (STATIC_QUIT_PART_SET)
+	{
+		sendto_one(sptr, ":%s %i %s :static-quit-part-set: %s", me.name, RPL_TEXT, 
+			sptr->name, "all");
+	}
+	else
+		sendto_one(sptr, ":%s %i %s :static-quit-part-set: %s", me.name, RPL_TEXT, 
+			sptr->name, "unregistered"));
+	if (STATIC_QUIT_PART_TIME == -1)
+	{
+		sendto_one(sptr, ":%s %i %s :static-quit-part-time: %s", me.name, RPL_TEXT, 
+			sptr->name, "STATIC");
+	}
+	else
+	{
+		sendto_one(sptr, ":%s %i %s :static-quit-part-time: %s", me.name, RPL_TEXT, 
+			sptr->name, pretty_time_val(STATIC_QUIT_PART_TIME));
+	}
 	sendto_one(sptr, ":%s %i %s :static-quit: %s", me.name, 
 		RPL_TEXT, sptr->name, STATIC_QUIT ? STATIC_QUIT : "<none>");	
 	sendto_one(sptr, ":%s %i %s :static-part: %s", me.name, 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -6839,6 +6839,33 @@ int	_conf_set(ConfigFile *conf, ConfigEntry *ce)
 		else if (!strcmp(cep->ce_varname, "level-on-join")) {
 			tempiConf.level_on_join = channellevel_to_int(cep->ce_vardata);
 		}
+		/* setting "all" will enforce static-quit and static-part to all users
+		 * 
+		 * setting "unregistered" will enforce static-quit and static-part to
+		 * unregistered users only -dboyz
+		 * TODO: Produce error message by adding else
+		 */
+		else if (!strcmp(cep->ce_varname, "static-quit-part-set")) {
+			if(!strcmp(ce->ce_vardata, "all"))
+				tempiConf.static_quit_part_set = 0;
+			else if (!strcmp(ce->vardata, "unregistered"))
+				tempiConf.static_quit_part_set = 1;
+		}
+		/* setting a valid value according to config_checkval will enforce 
+		 * static-quit and static-part to newly connected users during the 
+		 * duration specified
+		 *
+		 * setting value 0 disables the feature
+		 *
+		 * setting "static" will enforce static-quit and static-part all the
+		 * time -dboyz
+		 */
+		else if (!strcmp(cep->ce_varname, "static-quit-part-time")) {
+			if(!strcmp(ce->ce_vardata, "static"))
+				tempiConf.static_quit_part_time = -1;
+			else
+				tempiConf.static_quit_part_time = config_checkval(cep->ce_vardata,CFG_TIME);
+		}
 		else if (!strcmp(cep->ce_varname, "static-quit")) {
 			ircstrdup(tempiConf.static_quit, cep->ce_vardata);
 		}
@@ -7429,6 +7456,14 @@ int	_test_set(ConfigFile *conf, ConfigEntry *ce)
 					cep->ce_fileptr->cf_filename, cep->ce_varlinenum, cep->ce_vardata);
 				errors++;
 			}
+		}
+		else if (!strcmp(cep->ce_varname, "static-quit-part-set")) {
+			CheckNull(cep);
+			CheckDuplicate(cep, static_quit_part_set, "static-quit-part-set");
+		}
+		else if (!strcmp(cep->ce_varname, "static-quit-part-time")) {
+			CheckNull(cep);
+			CheckDuplicate(cep, static_quit_part_time, "static-quit-part-time");
 		}
 		else if (!strcmp(cep->ce_varname, "static-quit")) {
 			CheckNull(cep);

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -1445,6 +1445,7 @@ void	free_iConf(aConfiguration *i)
 	ircfree(i->oper_snomask);
 	ircfree(i->user_snomask);
 	ircfree(i->egd_path);
+	ircfree(i->static_part);
 	ircfree(i->static_quit);
 #ifdef USE_SSL
 	ircfree(i->x_server_cert_pem);

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -6927,9 +6927,6 @@ int	_conf_set(ConfigFile *conf, ConfigEntry *ce)
 		else if (!strcmp(cep->ce_varname, "new-linking-protocol")) {
 			tempiConf.new_linking_protocol = atoi(cep->ce_vardata);
 		}
-		else if (!strcmp(cep->ce_varname, "anti-spam-quit-message-time")) {
-			tempiConf.anti_spam_quit_message_time = config_checkval(cep->ce_vardata,CFG_TIME);
-		}
 		else if (!strcmp(cep->ce_varname, "oper-only-stats")) {
 			if (!cep->ce_entries)
 			{
@@ -7522,10 +7519,6 @@ int	_test_set(ConfigFile *conf, ConfigEntry *ce)
 					errors++;
 				}
 			}
-		}
-		else if (!strcmp(cep->ce_varname, "anti-spam-quit-message-time")) {
-			CheckNull(cep);
-			CheckDuplicate(cep, anti_spam_quit_message_time, "anti-spam-quit-message-time");
 		}
 		else if (!strcmp(cep->ce_varname, "oper-only-stats")) {
 			CheckDuplicate(cep, oper_only_stats, "oper-only-stats");


### PR DESCRIPTION
Added ability to limit STATIC_QUIT and STATIC_PART to only unregistered users based on original katsklaw's patch.
TODO: Edit config file and update docs
